### PR TITLE
lock to '~> v2'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<img width="877" height="138" alt="image" src="https://github.com/user-attachments/assets/3d6f75b9-8d8d-4a24-b134-034a118d4d67" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release pipeline to use the GoReleaser v2 series, ensuring more consistent and reliable build publishing across environments. Aligns CI with supported tooling versions and improves maintainability of automated releases. No user-facing changes; functionality and interfaces remain unchanged. No action required from users. Deployment cadence and artifacts remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->